### PR TITLE
将“riot”修改为“matrix”

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 - 快讯和唠叨频道：
 	- Telegram: https://t.me/liveslak  
-	- IRC/Riot 頻道 #Digitalrightscn 
+	- IRC/Matrix 頻道 #Digitalrightscn 
 
 *（欢迎参与协作）*
 
@@ -40,10 +40,10 @@
 
 ## 「數字權利」相关群組／頻道
 
-- **Riot 房間** （與 IRC 頻道同步） **「推荐」**
+- **Matrix 房間** （與 IRC 頻道同步） **「推荐」**
  - #digitalrightscn:matrix.org （數字權利相關）
  - #publicpolicy-cn:matrix.org （公共政策相關）
- - (加入姿势：Riot客户端中，在 Room Directory 搜索如 #digitalrightscn 即可进入。Riot 也有網頁版: https://riot.im/app ）
+ - (加入姿势：使用 Matrix 客戶端(推薦使用 Riot)，在 Room Directory 搜索如 #digitalrightscn 即可进入。Riot 也有網頁版: https://riot.im/app ）
 
 - **IRC 頻道**：
  - #DigitalRightsCN


### PR DESCRIPTION
尽管 riot 是目前唯一比较完善的 matrix 客户端，但是使用 riot 称呼整个网络会造成不少误解。